### PR TITLE
Added quotes around interface name in sample config

### DIFF
--- a/config/sample-eemo.conf
+++ b/config/sample-eemo.conf
@@ -57,7 +57,7 @@ capture:
 	# specified on the command line with the -i flag and defaults to the
 	# interface returned by pcap_lookupdev(3))
 	#
-	# interface = eth0;
+	# interface = "eth0";
 
 	# FILE options
 	#


### PR DESCRIPTION
Uncommenting this line caused a syntax error
